### PR TITLE
Reduce default number of 'higgs' rows to '100,000'

### DIFF
--- a/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
+++ b/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
@@ -67,7 +67,9 @@
     "import matplotlib.pyplot as plt\n",
     "import os\n",
     "import requests\n",
-    "import sys"
+    "import sys\n",
+    "import warnings\n",
+    "warnings.filterwarnings("ignore")"
    ]
   },
   {
@@ -107,7 +109,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We will run this model and prediction using 1,000,000 rows of the Higgs dataset."
+    "We will run this model and prediction using 100,000 rows of the Higgs dataset."
    ]
   },
   {
@@ -116,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_data, train_label, test_data, test_label, n_classes, n_features = load_higgs(990000, 10000)"
+    "train_data, train_label, test_data, test_label, n_classes, n_features = load_higgs(100000, 10000)"
    ]
   },
   {

--- a/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
+++ b/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
@@ -69,6 +69,7 @@
     "import requests\n",
     "import sys\n",
     "import warnings\n",
+    "\n",
     "warnings.filterwarnings(\"ignore\")"
    ]
   },

--- a/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
+++ b/E2E_use_case_with_Intel_optimized_XGBoost_daal4py/IntelPython_XGBoost_daal4pyPrediction.ipynb
@@ -69,7 +69,7 @@
     "import requests\n",
     "import sys\n",
     "import warnings\n",
-    "warnings.filterwarnings("ignore")"
+    "warnings.filterwarnings(\"ignore\")"
    ]
   },
   {


### PR DESCRIPTION
- reduce the number of default `higgs` data rows to process to `100,000`
- silent some unnecessary warnings' noise